### PR TITLE
fix: iterative review fixes for Phases 1-3

### DIFF
--- a/apps/web/app/flow/page.tsx
+++ b/apps/web/app/flow/page.tsx
@@ -63,6 +63,7 @@ export default function FlowPage() {
           pressureHpa: next.pressureHpa,
           moonPhase: next.moonPhase,
           season: next.season,
+          bundesland: next.bundesland || undefined,
         },
       },
     });

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { ApolloWrapper } from "./providers";
 import "./globals.css";
 
@@ -19,16 +20,16 @@ export default function RootLayout({
         <ApolloWrapper>
           <header className="border-b border-border">
             <nav className="max-w-content mx-auto px-4 py-4 flex items-center justify-between">
-              <a href="/" className="text-xl font-bold text-accent">
+              <Link href="/" className="text-xl font-bold text-accent">
                 The Fishing Masters
-              </a>
+              </Link>
               <div className="flex gap-4 text-sm text-text-muted">
-                <a href="/flow" className="hover:text-accent transition-colors">
+                <Link href="/flow" className="hover:text-accent transition-colors">
                   Empfehlung
-                </a>
-                <a href="/feedback" className="hover:text-accent transition-colors">
+                </Link>
+                <Link href="/feedback" className="hover:text-accent transition-colors">
                   Feedback
-                </a>
+                </Link>
               </div>
             </nav>
           </header>

--- a/apps/web/components/flow/SpotCard.tsx
+++ b/apps/web/components/flow/SpotCard.tsx
@@ -12,15 +12,26 @@ interface Spot {
   avgCrowdLevel: number;
 }
 
+interface Breakdown {
+  bite: number;
+  quality: number;
+  convenience: number;
+  crowd: number;
+  personal: number;
+  total: number;
+  reasons: string[];
+}
+
 interface Props {
   rank: number;
   spot: Spot;
   score: number;
   reason: string;
   bestWindow: string;
+  breakdown: Breakdown;
 }
 
-export default function SpotCard({ rank, spot, score, reason, bestWindow }: Props) {
+export default function SpotCard({ rank, spot, score, reason, bestWindow, breakdown }: Props) {
   const rankColors = ["text-accent", "text-warning", "text-text-muted"];
   const rankBorders = ["border-accent/40", "border-warning/40", "border-border"];
 
@@ -45,11 +56,11 @@ export default function SpotCard({ rank, spot, score, reason, bestWindow }: Prop
 
       {/* Score Breakdown Bars */}
       <div className="space-y-1.5 mb-4">
-        <ScoreBar label="Beißchance" value={score * 0.4} max={40} color="bg-accent" />
-        <ScoreBar label="Qualität" value={score * 0.25} max={25} color="bg-success" />
-        <ScoreBar label="Convenience" value={score * 0.15} max={15} color="bg-warning" />
-        <ScoreBar label="Crowd" value={score * 0.15} max={15} color="bg-accent-dim" />
-        <ScoreBar label="Personal" value={score * 0.05} max={5} color="bg-text-muted" />
+        <ScoreBar label="Beißchance" value={breakdown.bite} max={40} color="bg-accent" />
+        <ScoreBar label="Qualität" value={breakdown.quality} max={25} color="bg-success" />
+        <ScoreBar label="Convenience" value={breakdown.convenience} max={15} color="bg-warning" />
+        <ScoreBar label="Crowd" value={breakdown.crowd} max={15} color="bg-accent-dim" />
+        <ScoreBar label="Personal" value={breakdown.personal} max={5} color="bg-text-muted" />
       </div>
 
       {/* Reason */}

--- a/apps/web/components/flow/StepFish.tsx
+++ b/apps/web/components/flow/StepFish.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { FISH_SPECIES, BUNDESLAENDER } from "@/lib/constants";
+import { FISH_GROUPS, BUNDESLAENDER } from "@/lib/constants";
 import type { FlowState } from "@/app/flow/page";
 
 interface Props {
@@ -34,27 +34,13 @@ export default function StepFish({ onNext, initial }: Props) {
             required
           >
             <option value="">Fischart wählen...</option>
-            <optgroup label="Raubfische">
-              {FISH_SPECIES.filter((_, i) => i < 5).map((f) => (
-                <option key={f} value={f}>{f}</option>
-              ))}
-            </optgroup>
-            <optgroup label="Friedfische">
-              {FISH_SPECIES.filter((_, i) => i >= 5 && i < 9).map((f) => (
-                <option key={f} value={f}>{f}</option>
-              ))}
-            </optgroup>
-            <optgroup label="Salmoniden">
-              <option value="Forelle">Forelle</option>
-            </optgroup>
-            <optgroup label="Sonstige">
-              <option value="Aal">Aal</option>
-            </optgroup>
-            <optgroup label="Köderfische">
-              {FISH_SPECIES.filter((_, i) => i >= 11).map((f) => (
-                <option key={f} value={f}>{f}</option>
-              ))}
-            </optgroup>
+            {Object.entries(FISH_GROUPS).map(([group, species]) => (
+              <optgroup key={group} label={group}>
+                {species.map((f) => (
+                  <option key={f} value={f}>{f}</option>
+                ))}
+              </optgroup>
+            ))}
           </select>
         </div>
 

--- a/apps/web/components/flow/StepResults.tsx
+++ b/apps/web/components/flow/StepResults.tsx
@@ -3,6 +3,16 @@
 import SpotCard from "./SpotCard";
 import type { FlowState } from "@/app/flow/page";
 
+interface Breakdown {
+  bite: number;
+  quality: number;
+  convenience: number;
+  crowd: number;
+  personal: number;
+  total: number;
+  reasons: string[];
+}
+
 interface Recommendation {
   spot: {
     id: string;
@@ -17,6 +27,7 @@ interface Recommendation {
   score: number;
   reason: string;
   bestWindow: string;
+  breakdown: Breakdown;
 }
 
 interface Props {
@@ -63,6 +74,7 @@ export default function StepResults({ recommendations, state, onReset }: Props) 
               score={rec.score}
               reason={rec.reason}
               bestWindow={rec.bestWindow}
+              breakdown={rec.breakdown}
             />
           ))}
         </div>

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -1,28 +1,14 @@
-/** All fish species available for recommendation. */
-export const FISH_SPECIES = [
-  // Raubfische
-  "Zander",
-  "Hecht",
-  "Barsch",
-  "Wels",
-  "Rapfen",
-  // Friedfische
-  "Karpfen",
-  "Schleie",
-  "Barbe",
-  "Döbel",
-  // Salmoniden
-  "Forelle",
-  // Aal
-  "Aal",
-  // Köderfische
-  "Köderfisch",
-  "Rotauge",
-  "Rotfeder",
-  "Ukelei",
-  "Gründling",
-  "Güster",
-] as const;
+/** Fish species grouped by category. */
+export const FISH_GROUPS = {
+  Raubfische: ["Zander", "Hecht", "Barsch", "Wels", "Rapfen"],
+  Friedfische: ["Karpfen", "Schleie", "Barbe", "Döbel"],
+  Salmoniden: ["Forelle"],
+  Sonstige: ["Aal"],
+  "Köderfische": ["Köderfisch", "Rotauge", "Rotfeder", "Ukelei", "Gründling", "Güster"],
+} as const;
+
+/** All fish species available for recommendation (flat list). */
+export const FISH_SPECIES = Object.values(FISH_GROUPS).flat();
 
 export const BUNDESLAENDER = [
   "Sachsen-Anhalt",

--- a/apps/web/lib/graphql/queries.ts
+++ b/apps/web/lib/graphql/queries.ts
@@ -39,6 +39,30 @@ export const RECOMMENDATIONS_QUERY = gql`
       score
       reason
       bestWindow
+      breakdown {
+        bite
+        quality
+        convenience
+        crowd
+        personal
+        total
+        reasons
+      }
+    }
+  }
+`;
+
+export const SPOT_QUERY = gql`
+  query Spot($id: ID!) {
+    spot(id: $id) {
+      id
+      name
+      latitude
+      longitude
+      bundesland
+      gewaesserTyp
+      fishSpecies
+      avgCrowdLevel
     }
   }
 `;

--- a/infra/supabase/migrations/002_extend_schema.sql
+++ b/infra/supabase/migrations/002_extend_schema.sql
@@ -20,9 +20,9 @@ alter table public.spots
 -- Location-Index
 create index if not exists idx_spots_location on public.spots (latitude, longitude);
 
--- Profiles
+-- Profiles (FK to auth.users for RLS integration)
 create table if not exists public.profiles (
-  id uuid primary key,
+  id uuid primary key references auth.users(id) on delete cascade,
   display_name text,
   preferred_species jsonb default '[]'::jsonb,
   home_latitude decimal(9,6),

--- a/infra/supabase/seed.sql
+++ b/infra/supabase/seed.sql
@@ -3,6 +3,10 @@
 -- Sachsen-Anhalt, Thueringen, Sachsen
 -- ============================================================
 
+-- Ensure name+bundesland is unique so ON CONFLICT works
+alter table public.spots add constraint spots_name_bundesland_unique
+  unique (name, bundesland);
+
 insert into public.spots (name, latitude, longitude, bundesland, gewaesser_typ, fischarten, regelung, angelkarte_preis_tag, flaeche_ha, max_tiefe_m, strukturen, parkplatz, beschreibung) values
 
 -- ===================== SACHSEN-ANHALT =====================
@@ -218,4 +222,4 @@ insert into public.spots (name, latitude, longitude, bundesland, gewaesser_typ, 
  '["Inseln","Buchten","Steinschuettungen","Flachwasser"]', true,
  'Grosser See im Lausitzer Seenland. Vielversprechendes Raubfischgewaesser.')
 
-on conflict do nothing;
+on conflict (name, bundesland) do nothing;

--- a/services/api/schema.graphql
+++ b/services/api/schema.graphql
@@ -26,6 +26,7 @@ type Recommendation {
   score: Float!
   reason: String!
   bestWindow: String!
+  breakdown: ScoreBreakdown!
 }
 
 type Health {
@@ -39,11 +40,13 @@ input RecommendationInput {
   pressureHpa: Float!
   moonPhase: Float!
   season: String!
+  bundesland: String
 }
 
 type Query {
   health: Health!
   spots(bundesland: String, fishSpecies: String): [Spot!]!
+  spot(id: ID!): Spot
   recommendations(input: RecommendationInput!): [Recommendation!]!
 }
 

--- a/services/api/src/db/supabase.ts
+++ b/services/api/src/db/supabase.ts
@@ -4,14 +4,18 @@ let client: SupabaseClient | null = null;
 
 /**
  * Returns a singleton Supabase client.
- * Reads SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY from env.
- * Falls back to SUPABASE_ANON_KEY if service role is not set.
+ * Reads SUPABASE_URL and SUPABASE_ANON_KEY from env.
+ * Uses anon key by default so RLS policies are enforced.
+ * Only uses service role key when SUPABASE_USE_SERVICE_ROLE=true.
  */
 export function getSupabase(): SupabaseClient {
   if (client) return client;
 
   const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_ANON_KEY;
+  const useServiceRole = process.env.SUPABASE_USE_SERVICE_ROLE === 'true';
+  const key = useServiceRole
+    ? (process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_ANON_KEY)
+    : (process.env.SUPABASE_ANON_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY);
 
   if (!url || !key) {
     throw new Error(

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -15,6 +15,7 @@ type RecommendationInput = {
   pressureHpa: number;
   moonPhase: number;
   season: string;
+  bundesland?: string;
 };
 
 type FeedbackInput = {
@@ -68,12 +69,23 @@ const resolvers = {
       return (data as SpotRow[]).map(mapSpot);
     },
 
+    spot: async (_: unknown, args: { id: string }) => {
+      const db = getSupabase();
+      const { data, error } = await db.from('spots').select('*').eq('id', args.id).single();
+      if (error) return null;
+      return data ? mapSpot(data as SpotRow) : null;
+    },
+
     recommendations: async (_: unknown, args: { input: RecommendationInput }) => {
       const { input } = args;
       const db = getSupabase();
 
-      // 1. Fetch all spots (MVP – later filter by region/radius)
-      const { data: spots, error } = await db.from('spots').select('*');
+      // 1. Fetch spots, filtered by bundesland if provided
+      let query = db.from('spots').select('*');
+      if (input.bundesland) {
+        query = query.eq('bundesland', input.bundesland);
+      }
+      const { data: spots, error } = await query;
       if (error) throw new Error(`DB error: ${error.message}`);
       if (!spots || spots.length === 0) {
         throw new Error('Keine Angelstellen in der Datenbank gefunden.');
@@ -111,6 +123,7 @@ const resolvers = {
       return ranked.map((r) => ({
         spot: mapSpot(r.spot),
         score: r.score,
+        breakdown: r.breakdown,
         reason: r.reason,
         bestWindow: r.bestWindow,
       }));
@@ -126,6 +139,7 @@ const resolvers = {
         spot_id: input.spotId,
         success: input.success,
         note: input.note ?? null,
+        user_id: null,  // Anonymous feedback allowed; auth users set via RLS context
       });
 
       if (error) throw new Error(`Feedback error: ${error.message}`);

--- a/services/ml/app.py
+++ b/services/ml/app.py
@@ -146,7 +146,11 @@ def lunar(
 ) -> LunarResponse:
     """Get lunar phase and solunar periods for a date/location."""
     if target_date:
-        d = date.fromisoformat(target_date)
+        try:
+            d = date.fromisoformat(target_date)
+        except ValueError:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=422, detail=f"Ungültiges Datum: '{target_date}'. Format: YYYY-MM-DD")
     else:
         d = date.today()
 

--- a/services/ml/lunar.py
+++ b/services/ml/lunar.py
@@ -51,22 +51,18 @@ def _moon_phase_angle(dt: datetime) -> float:
     Calculate the moon's phase angle (0-360 degrees).
     0/360 = New Moon, 180 = Full Moon.
 
-    Simplified algorithm based on Meeus ch. 49.
+    Uses the synodic month approach: fraction of the current lunar cycle
+    mapped to 0-360 degrees. More reliable than simplified elongation.
     """
+    # Known new moon reference: January 6, 2000 at 18:14 UTC
+    KNOWN_NEW_MOON_JD = 2451550.26
+    SYNODIC_MONTH = 29.53059  # days
+
     jd = _julian_day(dt)
-    # Days since J2000.0
-    T = (jd - 2451545.0) / 36525.0
-
-    # Sun's mean anomaly
-    M = math.radians(357.5291 + 35999.0503 * T)
-    # Moon's mean anomaly
-    Mp = math.radians(134.9634 + 477198.8676 * T)
-    # Moon's mean elongation
-    D = math.radians(297.8502 + 445267.1115 * T)
-
-    # Phase angle (simplified)
-    phase = D * 2  # Convert elongation to phase
-    phase_deg = math.degrees(phase) % 360
+    days_since = jd - KNOWN_NEW_MOON_JD
+    # Phase within current cycle (0.0 = new, 0.5 = full, 1.0 = new again)
+    cycle_fraction = (days_since % SYNODIC_MONTH) / SYNODIC_MONTH
+    phase_deg = cycle_fraction * 360.0
 
     return phase_deg
 

--- a/services/ml/scoring.py
+++ b/services/ml/scoring.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 SEASON_BONUS = {"Fruehling": 6.0, "Sommer": 4.0, "Herbst": 8.0, "Winter": -5.0}
 
 
@@ -11,11 +13,27 @@ def compute_bite_probability(
     moon_phase: float,
     season: str,
 ) -> float:
+    """
+    Compute baseline bite probability (5-95%).
+
+    Args:
+        water_temp_c: Water temperature in Celsius (0-35)
+        wind_kmh: Wind speed in km/h (0-120)
+        pressure_hpa: Barometric pressure in hPa (850-1100)
+        moon_phase: Moon phase percentage (0=New, 50=Full, 100=New)
+        season: One of Fruehling, Sommer, Herbst, Winter
+    """
     temp_bonus = max(0.0, 18 - abs(water_temp_c - 14)) * 1.8
     wind_penalty = max(0.0, wind_kmh - 18) * 1.0
     pressure_bonus = max(0.0, 20 - abs(pressure_hpa - 1015)) * 0.7
-    lunar_bonus = (50 - abs(moon_phase - 55)) * 0.25
-    season_bonus = SEASON_BONUS[season]
+
+    # Lunar bonus: best fishing at new moon (0/100) and full moon (50)
+    # Uses cosine to create peaks at both new and full moon,
+    # consistent with species_rules.py
+    lunar_effect = (math.cos(moon_phase * 2 * math.pi / 100) + 1) / 2  # 0-1
+    lunar_bonus = (lunar_effect - 0.3) * 15  # -4.5 to +10.5
+
+    season_bonus = SEASON_BONUS.get(season, 0.0)
 
     score = 40 + temp_bonus + pressure_bonus + lunar_bonus + season_bonus - wind_penalty
     return max(5.0, min(95.0, round(score, 2)))

--- a/services/ml/species_rules.py
+++ b/services/ml/species_rules.py
@@ -7,6 +7,7 @@ for common freshwater fish species in Central Germany.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 
@@ -259,14 +260,15 @@ def get_species_profile(species: str) -> SpeciesProfile | None:
     # Direct match
     if species in SPECIES_DB:
         return SPECIES_DB[species]
-    # Case-insensitive
+    # Case-insensitive match against DB keys
+    species_lower = species.lower()
     for key, profile in SPECIES_DB.items():
-        if key.lower() == species.lower():
+        if key.lower() == species_lower:
             return profile
-    # Alias
-    alias = _ALIASES.get(species)
-    if alias and alias in SPECIES_DB:
-        return SPECIES_DB[alias]
+    # Case-insensitive alias lookup
+    for alias_key, alias_target in _ALIASES.items():
+        if alias_key.lower() == species_lower:
+            return SPECIES_DB.get(alias_target)
     return None
 
 
@@ -362,5 +364,3 @@ def get_lure_recommendation(species: str, season: str) -> dict[str, list[str]]:
     }
 
 
-# Needed for moon_phase_pct calculation in compute_species_score
-import math

--- a/services/ml/weather_client.py
+++ b/services/ml/weather_client.py
@@ -58,12 +58,20 @@ def _get_cached(lat: float, lon: float) -> WeatherData | None:
         ts, data = _cache[key]
         if time.time() - ts < CACHE_TTL_S:
             return WeatherData(**data)
+        # Evict expired entry
+        del _cache[key]
     return None
 
 
 def _set_cache(lat: float, lon: float, data: WeatherData) -> None:
     key = _cache_key(lat, lon)
     _cache[key] = (time.time(), data.to_dict())
+    # Periodic cleanup: evict all expired entries when cache grows large
+    if len(_cache) > 200:
+        now = time.time()
+        expired = [k for k, (ts, _) in _cache.items() if now - ts >= CACHE_TTL_S]
+        for k in expired:
+            del _cache[k]
 
 
 def get_api_key() -> str | None:

--- a/tests/test_lunar.py
+++ b/tests/test_lunar.py
@@ -1,12 +1,12 @@
 import unittest
-from datetime import date
+from datetime import date, datetime, timezone
 
 from services.ml.lunar import (
     compute_moon_phase,
     compute_solunar_periods,
     get_lunar_data,
+    _julian_day,
 )
-from datetime import datetime, timezone
 
 
 class LunarTests(unittest.TestCase):
@@ -30,13 +30,48 @@ class LunarTests(unittest.TestCase):
         ]
         self.assertIn(name, valid_names)
 
+    def test_julian_day_known_value(self):
+        """J2000.0 = JD 2451545.0 at Jan 1.5, 2000 (noon UTC)."""
+        dt = datetime(2000, 1, 1, 12, 0, tzinfo=timezone.utc)
+        jd = _julian_day(dt)
+        self.assertAlmostEqual(jd, 2451545.0, places=1)
+
+    def test_known_new_moon(self):
+        """Jan 29, 2025 was a known new moon – phase should be near 0 or 100."""
+        dt = datetime(2025, 1, 29, 12, 14, tzinfo=timezone.utc)
+        pct, name, illum = compute_moon_phase(dt)
+        # Should be near new moon (0 or 100)
+        near_new = pct < 8 or pct > 92
+        self.assertTrue(near_new, f"Expected near new moon, got phase_pct={pct}")
+        self.assertLess(illum, 15, f"Expected low illumination at new moon, got {illum}")
+
+    def test_known_full_moon(self):
+        """Feb 12, 2025 was a known full moon – phase should be near 50."""
+        dt = datetime(2025, 2, 12, 13, 53, tzinfo=timezone.utc)
+        pct, name, illum = compute_moon_phase(dt)
+        self.assertAlmostEqual(pct, 50, delta=8,
+                               msg=f"Expected near full moon (50), got {pct}")
+        self.assertGreater(illum, 85, f"Expected high illumination at full moon, got {illum}")
+
+    def test_full_moon_not_reported_as_new(self):
+        """Regression: full moon must not be reported as new moon."""
+        # Test several known full moons
+        full_moons = [
+            datetime(2025, 2, 12, 13, 0, tzinfo=timezone.utc),
+            datetime(2025, 7, 10, 20, 0, tzinfo=timezone.utc),
+            datetime(2025, 12, 4, 23, 0, tzinfo=timezone.utc),
+        ]
+        for dt in full_moons:
+            pct, name, _ = compute_moon_phase(dt)
+            self.assertGreater(pct, 35, f"{dt.date()}: phase_pct={pct}, expected >35")
+            self.assertLess(pct, 65, f"{dt.date()}: phase_pct={pct}, expected <65")
+
     def test_solunar_periods_format(self):
         majors, minors, rating = compute_solunar_periods(
             date(2026, 3, 26), 51.3, 12.0
         )
         self.assertEqual(len(majors), 2)
         self.assertEqual(len(minors), 2)
-        # Check time format HH:MM
         for start, end in majors + minors:
             self.assertRegex(start, r"^\d{2}:\d{2}$")
             self.assertRegex(end, r"^\d{2}:\d{2}$")


### PR DESCRIPTION
Phase 2 (ML/Python):
- Fix lunar.py: replace broken phase calculation with synodic month approach
- Fix scoring.py: align lunar bonus to cosine function (consistent with species_rules)
- Fix species_rules.py: move math import to top, case-insensitive alias lookup
- Fix weather_client.py: evict expired cache entries, periodic cleanup
- Fix app.py: return 422 instead of 500 on invalid date in /lunar endpoint
- Add 4 lunar accuracy tests (known new/full moons, regression checks)

Phase 1 (Backend/Schema):
- Add bundesland to RecommendationInput in GraphQL schema
- Connect ScoreBreakdown to Recommendation type
- Add spot(id) query for detail pages
- Filter spots by bundesland in recommendations resolver
- Return real breakdown data from scorer in resolver
- Fix migration 002: add FK to auth.users on profiles table
- Fix seed.sql: add unique constraint (name, bundesland) for ON CONFLICT
- Fix supabase.ts: prefer anon key by default (RLS enforced)
- Fix submitFeedback: explicitly set user_id null for anonymous feedback

Phase 3 (Next.js):
- Fix SpotCard: use real ScoreBreakdown from API instead of fabricated values
- Fix layout.tsx: replace <a> tags with Next.js <Link> for client-side nav
- Fix StepFish.tsx: replace fragile index-based fish categorization with FISH_GROUPS
- Add bundesland to recommendations query variables
- Add SPOT_QUERY for detail pages

All 34 Python tests pass.

https://claude.ai/code/session_01PFccg7JCC2T2ZoNMWoTjD4